### PR TITLE
better Linux compatibility

### DIFF
--- a/lib/abcrunch/logger.rb
+++ b/lib/abcrunch/logger.rb
@@ -1,3 +1,5 @@
+require File.join(File.dirname(__FILE__), 'log_console_writer')
+
 module AbCrunch
   module Logger
     class << self


### PR DESCRIPTION
I tried out `abcrunch` on a project yesterday, and I've been enjoying using it.

After pushing an `abcrunch`-based rake task to master, we found that `require 'abcrunch'` raises an error on our Ubuntu Jenkins box:

```
Unable to require abcrunch. NameError: uninitialized constant AbCrunch::LogConsoleWriter.
```

The issue seems to be that on OS X, `log_console_writer.rb` is being required before `logger.rb`, which works, but on Linux, `logger.rb` is being required first, which gives the missing constant error. Since Logger depends on LogConsoleWriter, this pull request makes that explicit by adding a `require` to `logger.rb`.

If you want to reproduce the error and the fix on a linux vm, `bundle exec ruby -e 'require "abcrunch"' is a good one-liner for it.
